### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# ipfs-mans
+# DEPRECATED: ipfs-mans
+
+**This project is no longer maintained as of August 16, 2018.** Keeping in-app help, specifications, online documentation *and* man pages up-to-date turned out to be too many places to keep in-sync and updated. Instead, we’re putting more effort into our documentation site at https://docs.ipfs.io. (You can contribute to it at https://github.com/ipfs/docs.)
+
 The IPFS CLI Manuals


### PR DESCRIPTION
Is this reasonable and accurate, @RichardLitt?

I don’t have admin permissions here, so once we merge this, can you please:

1. Prefix the repo description with `DEPRECATED:`
2. Add the topic tag `deprecated`
3. Archive the repo?